### PR TITLE
Fix backwards compatibility error with C++20

### DIFF
--- a/slot_map/slot_map.h
+++ b/slot_map/slot_map.h
@@ -167,6 +167,7 @@ template <typename T> struct slot_map_key
     }
 
     slot_map_key() noexcept = default;
+    slot_map_key(id_type raw) noexcept : raw(raw) { }
     slot_map_key(const slot_map_key&) noexcept = default;
     slot_map_key& operator=(const slot_map_key&) noexcept = default;
     slot_map_key(slot_map_key&&) noexcept = default;


### PR DESCRIPTION
On C++20, compiling gives an error involving brace initializing `slot_map_key` with a parameter for `raw`. This changelist simply adds that constructor explicitly so that compilation succeeds in C++20.

For more information, see this stackoverflow thread:
https://stackoverflow.com/questions/57271400/why-does-aggregate-initialization-not-work-anymore-since-c20-if-a-constructor