### PR TITLE
Iterator bug fix

### DIFF
--- a/SlotMapTest01.cpp
+++ b/SlotMapTest01.cpp
@@ -305,11 +305,34 @@ TEST(SlotMapTest, ConstantGetter)
 TEST(SlotMapTest, IteratorsComparison)
 {
     dod::slot_map<std::string> slotMap;
-    EXPECT_FALSE(slotMap.begin() == slotMap.end());
-    EXPECT_TRUE(slotMap.begin() != slotMap.end());
+    EXPECT_FALSE(slotMap.begin() != slotMap.end());
+    EXPECT_TRUE(slotMap.begin() == slotMap.end());
 
-    EXPECT_FALSE(slotMap.items().begin() == slotMap.items().end());
-    EXPECT_TRUE(slotMap.items().begin() != slotMap.items().end());
+    EXPECT_FALSE(slotMap.items().begin() != slotMap.items().end());
+    EXPECT_TRUE(slotMap.items().begin() == slotMap.items().end());
+}
+
+TEST(SlotMapTest, Iterator)
+{
+    dod::slot_map<int> slotMap;
+    ASSERT_EQ(0u, slotMap.size());
+
+    auto id1 = slotMap.emplace(12);
+    auto id2 = slotMap.emplace(13);
+
+    ASSERT_TRUE(slotMap.has_key(id1));
+    ASSERT_TRUE(slotMap.has_key(id2));
+
+    slotMap.erase(id2);
+    ASSERT_FALSE(slotMap.has_key(id2));
+
+    for (const auto& [key, val] : slotMap.items()) {
+        EXPECT_TRUE(slotMap.has_key(key));
+        EXPECT_EQ(key, id1);
+    }
+    for (const auto& val : slotMap) {
+        EXPECT_EQ(val, 12);
+    }
 }
 
 std::atomic<int> ctorCount = 0;

--- a/slot_map/slot_map.h
+++ b/slot_map/slot_map.h
@@ -1172,8 +1172,10 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
 
     const_values_iterator begin() const noexcept
     {
+        if (pages.empty()) return end();
+
         size_type index = 0;
-        while (index <= getMaxValidIndex() && !pages.empty() && isTombstone(index))
+        while (index <= getMaxValidIndex() && isTombstone(index))
         {
             index++;
         }
@@ -1292,8 +1294,9 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
 
         const_kv_iterator begin() const noexcept
         {
+            if (slotMap->pages.empty()) return end();
             size_type index = 0;
-            while (index <= slotMap->getMaxValidIndex() && !slotMap->pages.empty() && slotMap->isTombstone(index))
+            while (index <= slotMap->getMaxValidIndex() && slotMap->isTombstone(index))
             {
                 index++;
             }

--- a/slot_map/slot_map.h
+++ b/slot_map/slot_map.h
@@ -1173,7 +1173,7 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
     const_values_iterator begin() const noexcept
     {
         size_type index = 0;
-        while (index <= getMaxValidIndex() && isTombstone(index))
+        while (index <= getMaxValidIndex() && !pages.empty() && isTombstone(index))
         {
             index++;
         }
@@ -1293,7 +1293,7 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
         const_kv_iterator begin() const noexcept
         {
             size_type index = 0;
-            while (index <= slotMap->getMaxValidIndex() && slotMap->isTombstone(index))
+            while (index <= slotMap->getMaxValidIndex() && !slotMap->pages.empty() && slotMap->isTombstone(index))
             {
                 index++;
             }

--- a/slot_map/slot_map.h
+++ b/slot_map/slot_map.h
@@ -1154,7 +1154,7 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
             do
             {
                 currentIndex++;
-            } while (currentIndex < slotMap->getMaxValidIndex() && slotMap->isTombstone(currentIndex));
+            } while (currentIndex <= slotMap->getMaxValidIndex() && slotMap->isTombstone(currentIndex));
             return *this;
         }
 
@@ -1173,7 +1173,7 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
     const_values_iterator begin() const noexcept
     {
         size_type index = 0;
-        while (index < getMaxValidIndex() && isTombstone(index))
+        while (index <= getMaxValidIndex() && isTombstone(index))
         {
             index++;
         }
@@ -1261,7 +1261,7 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
             do
             {
                 currentIndex++;
-            } while (currentIndex < slotMap->getMaxValidIndex() && slotMap->isTombstone(currentIndex));
+            } while (currentIndex <= slotMap->getMaxValidIndex() && slotMap->isTombstone(currentIndex));
             return *this;
         }
 
@@ -1293,7 +1293,7 @@ template <typename T, typename TKeyType = slot_map_key64<T>, size_t PAGESIZE = 4
         const_kv_iterator begin() const noexcept
         {
             size_type index = 0;
-            while (index < slotMap->getMaxValidIndex() && slotMap->isTombstone(index))
+            while (index <= slotMap->getMaxValidIndex() && slotMap->isTombstone(index))
             {
                 index++;
             }


### PR DESCRIPTION
Summary:
* Fix the off-by-one bug in iterator.
* Handle empty page case.
* Ensure `.begin() == .end()` when map is empty.